### PR TITLE
fix: app-settings: hide secrets from deploy-config

### DIFF
--- a/app/controllers/app_settings_controller.rb
+++ b/app/controllers/app_settings_controller.rb
@@ -120,7 +120,7 @@ class AppSettingsController < ApplicationController
     @context_for_views = CONTEXT_FOR_VIEWS
     @explore_page_settings = EXPLORE_PAGE_SETTINGS
     @deploy_config = ApplicationHelper.unwrap_and_hide_secrets(
-      Settings, blacklist: %w(secret api_key geheim))
+      Settings, blacklist: %w(secret password api_key geheim))
   end
 
   def app_setting_params

--- a/app/controllers/app_settings_controller.rb
+++ b/app/controllers/app_settings_controller.rb
@@ -119,7 +119,8 @@ class AppSettingsController < ApplicationController
     @settings_groups = SETTINGS_GROUPS
     @context_for_views = CONTEXT_FOR_VIEWS
     @explore_page_settings = EXPLORE_PAGE_SETTINGS
-    @deploy_config = unwrap_and_hide_secrets(Settings)
+    @deploy_config = ApplicationHelper.unwrap_and_hide_secrets(
+      Settings, blacklist: %w(secret api_key geheim))
   end
 
   def app_setting_params
@@ -146,20 +147,4 @@ class AppSettingsController < ApplicationController
     ::AppSetting.columns_hash[attr.to_s]
   end
 
-  def unwrap_and_hide_secrets(ostruct)
-    blacklist = %w(secret api_key geheim)
-    ostruct.marshal_dump.map do |key, val|
-      if val.is_a?(OpenStruct) # recurse
-        [key, unwrap_and_hide_secrets(val)]
-      elsif blacklist.any? { |s| key.to_s.include?(s) }
-        [key, obfuscate_secret(val)]
-      else
-        [key, val]
-      end
-    end.to_h.compact
-  end
-
-  def obfuscate_secret(string)
-    Array.new(string.try(:to_s).try(:length) || 3) { '*' }.join
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,4 +24,21 @@ module ApplicationHelper
   def default_filter_option
     content_tag :option, '(all)', value: ''
   end
+
+  def self.unwrap_and_hide_secrets(ostruct, blacklist:)
+    ostruct.marshal_dump.map do |key, val|
+      if val.is_a?(OpenStruct) # recurse
+        [key, unwrap_and_hide_secrets(val, blacklist: blacklist)]
+      elsif blacklist.any? { |s| key.to_s.include?(s) }
+        [key, obfuscate_secret(val)]
+      else
+        [key, val]
+      end
+    end.to_h.compact
+  end
+
+  def self.obfuscate_secret(string)
+    Array.new(string.try(:to_s).try(:length) || 3) { '*' }.join
+  end
+
 end

--- a/app/views/app_settings/index.html.haml
+++ b/app/views/app_settings/index.html.haml
@@ -27,7 +27,7 @@
 
 .panel.panel-default
   .panel-heading
-    .panel-title 
+    .panel-title
       'Explore' Page
   .panel-body#explore-page-section
     %table.table.table-striped
@@ -44,7 +44,7 @@
                 = collection_as_link(@app_settings.send(attr))
               - else
                 = @app_settings.send(attr)
-            
+
     = link_to edit_app_setting_path(:explore_page), class: 'btn btn-info btn-sm' do
       %span.glyphicon.glyphicon-edit
       Edit
@@ -56,6 +56,7 @@
 
 %p
   Configuration per server/instance.
+  Values are hidden if key contains "secret", "api_key" or "geheim".
   %span.text-danger Can only be changed on the server itself!
 
 %pre

--- a/app/views/app_settings/index.html.haml
+++ b/app/views/app_settings/index.html.haml
@@ -56,8 +56,11 @@
 
 %p
   Configuration per server/instance.
-  Values are hidden if key contains "secret", "api_key" or "geheim".
-  %span.text-danger Can only be changed on the server itself!
+%p.text-info
+  Values are hidden with stars (
+  %code<> *
+  ) if their key contains "secret", "password", "api_key" or "geheim".
+%p.text-danger Can only be changed on the server itself!
 
 %pre
   %code= @deploy_config.as_json.to_yaml


### PR DESCRIPTION
>  Values are hidden with stars (*) if their key contains "secret", "password", "api_key" or "geheim". 

FYI @DrTom 